### PR TITLE
KEEVO_WEBSOCKET_BRIDGE_POPUP_URL environment variable value was fixed

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,8 @@ const SOURCE_DIRECTORY_PATH = 'src';
 const DESTINATION_DIRECTORY_PATH = 'dist';
 
 function cleanTask() {
+  console.log('Cleaning');
+
   return del(DESTINATION_DIRECTORY_PATH);
 }
 
@@ -29,8 +31,6 @@ function preBuildCheckTask() {
     throw new Error('Popup URL is not a string');
   }
 
-  console.log('popupUrl', popupUrl);
-
   if (!/^https:\/\//.test(popupUrl)) {
     console.error('Popup URL is not starts with "https://"');
 
@@ -41,6 +41,8 @@ function preBuildCheckTask() {
 }
 
 function compileTypeScriptTask() {
+  console.log('Compiling');
+
   return tsProject.src()
     // In general is not reliable to check directly by string, but in our case it is ok
     .pipe(replace('process.env.KEEVO_WEBSOCKET_BRIDGE_POPUP_URL', `'${process.env.KEEVO_WEBSOCKET_BRIDGE_POPUP_URL}'`))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keevowallet/keevo-metamask-keyring",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Keevo keyring implementation",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Improved logging in build process.

Popup URL should ends with `/`. Otherwise URL in Firefox doesn't match the pattern to load content script